### PR TITLE
Fix widget toggle and sanitize settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A WordPress plugin providing a customizable floating WhatsApp button for easy vi
 * **Scroll Behavior:** Choose to display the widget constantly or have it hide on scroll.
 * **Easy Setup:** Simple settings page within the WordPress admin area.
 * **Widget Preview:** See changes reflected in real-time within the settings page.
+* **On/Off Toggle:** Enable or disable the widget globally from the settings page.
 
 ## Installation
 

--- a/floating-whatsapp-widget.php
+++ b/floating-whatsapp-widget.php
@@ -21,6 +21,32 @@ new FWW_Plugin_Updater(
     'Floating WhatsApp Widget'
 );
 
+// Sanitize callbacks
+function fww_sanitize_phone($input) {
+    return preg_replace('/[^0-9]/', '', $input);
+}
+
+function fww_sanitize_whatsapp_link($input) {
+    return esc_url_raw($input);
+}
+
+function fww_sanitize_use_link($input) {
+    return $input === 'link' ? 'link' : 'phone';
+}
+
+function fww_sanitize_color($input) {
+    $color = sanitize_hex_color($input);
+    return $color ? $color : '#25D366';
+}
+
+function fww_sanitize_position($input) {
+    return $input === 'bottom-left' ? 'bottom-left' : 'bottom-right';
+}
+
+function fww_sanitize_enabled($input) {
+    return $input ? '1' : '0';
+}
+
 // Add menu item to WordPress admin
 function fww_add_admin_menu() {
     add_menu_page(
@@ -36,11 +62,12 @@ add_action('admin_menu', 'fww_add_admin_menu');
 
 // Register plugin settings
 function fww_register_settings() {
-    register_setting('fww_settings', 'fww_phone');
-    register_setting('fww_settings', 'fww_whatsapp_link');
-    register_setting('fww_settings', 'fww_use_link');
-    register_setting('fww_settings', 'fww_color');
-    register_setting('fww_settings', 'fww_position');
+    register_setting('fww_settings', 'fww_phone', array('sanitize_callback' => 'fww_sanitize_phone'));
+    register_setting('fww_settings', 'fww_whatsapp_link', array('sanitize_callback' => 'fww_sanitize_whatsapp_link'));
+    register_setting('fww_settings', 'fww_use_link', array('sanitize_callback' => 'fww_sanitize_use_link'));
+    register_setting('fww_settings', 'fww_color', array('sanitize_callback' => 'fww_sanitize_color'));
+    register_setting('fww_settings', 'fww_position', array('sanitize_callback' => 'fww_sanitize_position'));
+    register_setting('fww_settings', 'fww_enabled', array('sanitize_callback' => 'fww_sanitize_enabled'));
 }
 add_action('admin_init', 'fww_register_settings');
 
@@ -94,6 +121,12 @@ function fww_settings_page() {
                         </select>
                     </td>
                 </tr>
+                <tr>
+                    <th scope="row">Enable Widget</th>
+                    <td>
+                        <input type="checkbox" name="fww_enabled" value="1" <?php checked(get_option('fww_enabled', '1'), '1'); ?> />
+                    </td>
+                </tr>
             </table>
             <?php submit_button(); ?>
         </form>
@@ -121,11 +154,15 @@ function fww_settings_page() {
 
 // Add the widget to the frontend
 function fww_add_widget() {
-    $use_link = get_option('fww_use_link', 'phone');
-    $phone = get_option('fww_phone');
+    if (is_admin() || !get_option('fww_enabled', '1')) {
+        return;
+    }
+
+    $use_link      = get_option('fww_use_link', 'phone');
+    $phone         = get_option('fww_phone');
     $whatsapp_link = get_option('fww_whatsapp_link');
-    $color = get_option('fww_color', '#25D366');
-    $position = get_option('fww_position', 'bottom-right');
+    $color         = get_option('fww_color', '#25D366');
+    $position      = get_option('fww_position', 'bottom-right');
 
     $link = $use_link === 'phone' 
         ? "https://wa.me/" . preg_replace('/[^0-9]/', '', $phone)

--- a/includes/plugin-updater.php
+++ b/includes/plugin-updater.php
@@ -102,7 +102,9 @@ class FWW_Plugin_Updater {
             'last_updated' => $release_info['published_at'],
             'sections' => array(
                 'description' => 'Floating WhatsApp Widget for WordPress',
-                'changelog' => wp_markdown_to_html($release_info['description']),
+                'changelog' => function_exists('wp_markdown_to_html') ?
+                    wp_markdown_to_html($release_info['description']) :
+                    wpautop($release_info['description']),
             ),
             'download_link' => $release_info['download_url'],
         );


### PR DESCRIPTION
## Summary
- sanitize plugin options
- add widget enable/disable toggle
- hide widget in admin
- avoid fatal error when Markdown helper missing
- document new toggle option in README

## Testing
- `php -l floating-whatsapp-widget.php` *(fails: command not found)*