### PR TITLE
Fix widget toggle and sanitize settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A WordPress plugin providing a customizable floating WhatsApp button for easy vi
 * **Scroll Behavior:** Choose to display the widget constantly or have it hide on scroll.
 * **Easy Setup:** Simple settings page within the WordPress admin area.
 * **Widget Preview:** See changes reflected in real-time within the settings page.
+* **On/Off Toggle:** Enable or disable the widget globally from the settings page.
 
 ## Installation
 
@@ -35,6 +36,11 @@ After configuring the settings, the WhatsApp widget will automatically appear on
 For any support requests, bug reports, or feature suggestions, please create a ticket on the [DesignThat Cloud Dashboard](https://designthat.cloud/open-ticket/hosting?subject=WhatsAppWidget)
 
 ## Changelog
+
+* **Version 1.4.1**
+    * Sanitized all widget options to prevent invalid values.
+    * Added an enable/disable toggle for showing the widget.
+    * Display a notice when settings are saved successfully.
 
 * **Version 1.3**
     * Added option to choose between using a phone number or a WhatsApp link.

--- a/includes/plugin-updater.php
+++ b/includes/plugin-updater.php
@@ -102,7 +102,9 @@ class FWW_Plugin_Updater {
             'last_updated' => $release_info['published_at'],
             'sections' => array(
                 'description' => 'Floating WhatsApp Widget for WordPress',
-                'changelog' => wp_markdown_to_html($release_info['description']),
+                'changelog' => function_exists('wp_markdown_to_html') ?
+                    wp_markdown_to_html($release_info['description']) :
+                    wpautop($release_info['description']),
             ),
             'download_link' => $release_info['download_url'],
         );


### PR DESCRIPTION
## Summary
- sanitize plugin options
- add widget enable/disable toggle
- hide widget in admin
- avoid fatal error when Markdown helper missing
- document new toggle option in README
- show message when settings are saved
- bump version to 1.4.1

## Testing
- `php -l floating-whatsapp-widget.php` *(fails: command not found)*